### PR TITLE
Experimental extra service with hardened mysql:8.4 using copilot, for ddev/ddev#7962

### DIFF
--- a/.ddev/docker-compose.mysql.yaml
+++ b/.ddev/docker-compose.mysql.yaml
@@ -1,0 +1,48 @@
+# DDEV Additional Service: Hardened MySQL 8.4
+# This service runs alongside the default database service
+
+services:
+  mysql84:
+    container_name: "ddev-${DDEV_SITENAME}-mysql84"
+    build:
+      context: ./mysql
+      dockerfile: Dockerfile
+    image: ddev-mysql84-${DDEV_SITENAME}-built
+    labels:
+      com.ddev.site-name: ${DDEV_SITENAME}
+      com.ddev.approot: ${DDEV_APPROOT}
+    restart: "no"
+    ports:
+      # Use different port from main db (3306)
+      - "127.0.0.1:3307:3306"
+    environment:
+      - MYSQL_ROOT_PASSWORD=root
+      - MYSQL_DATABASE=db
+      - MYSQL_USER=db
+      - MYSQL_PASSWORD=db
+      - TZ=America/Denver
+    volumes:
+      # Dedicated volume for this MySQL instance
+      - mysql84-data:/var/lib/mysql
+      # Mount project for configuration access
+      - .:/mnt/ddev_config:ro
+      # Snapshots directory
+      - ./mysql-snapshots:/mnt/snapshots
+    healthcheck:
+      test: ["CMD", "/healthcheck.sh"]
+      interval: 2s
+      timeout: 10s
+      retries: 30
+      start_period: 120s
+    networks:
+      - default
+    x-ddev:
+      describe-info: |
+        Hardened MySQL 8.4 service
+        Connect from host: mysql -h 127.0.0.1 -P 3307 -u root -proot
+        Connect from web: mysql -h mysql84 -u root -proot
+      describe-url-port: "3307:3306"
+
+volumes:
+  mysql84-data:
+    name: "${DDEV_SITENAME}-mysql84-data"

--- a/.ddev/mysql/Dockerfile
+++ b/.ddev/mysql/Dockerfile
@@ -1,0 +1,69 @@
+# ============================================================================
+# Stage 1: Builder - Install packages and collect dependencies
+# ============================================================================
+FROM debian:bookworm-slim AS builder
+
+# Install all required packages via apt
+RUN apt-get update && \
+    DEBIAN_FRONTEND=noninteractive apt-get install -y \
+    bzip2 \
+    curl \
+    less \
+    pv \
+    wget \
+    zstd \
+    ca-certificates \
+    file \
+    && rm -rf /var/lib/apt/lists/*
+
+# Create staging directory structure matching target filesystem
+RUN mkdir -p /staging/usr/bin \
+             /staging/usr/lib \
+             /staging/lib/x86_64-linux-gnu \
+             /staging/lib64 \
+             /staging/etc
+
+# Copy helper script for dependency resolution
+COPY copy-with-deps.sh /usr/local/bin/
+RUN chmod 755 /usr/local/bin/copy-with-deps.sh
+
+# Copy each binary and its dependencies to staging
+RUN /usr/local/bin/copy-with-deps.sh pv /staging
+RUN /usr/local/bin/copy-with-deps.sh zstd /staging
+RUN /usr/local/bin/copy-with-deps.sh unzstd /staging
+RUN /usr/local/bin/copy-with-deps.sh bzip2 /staging
+RUN /usr/local/bin/copy-with-deps.sh bunzip2 /staging
+RUN /usr/local/bin/copy-with-deps.sh curl /staging
+RUN /usr/local/bin/copy-with-deps.sh wget /staging
+RUN /usr/local/bin/copy-with-deps.sh less /staging
+
+# Add custom healthcheck script
+COPY healthcheck.sh /staging/healthcheck.sh
+RUN chmod 755 /staging/healthcheck.sh
+
+# ============================================================================
+# Stage 2: Hardened MySQL - Copy staged files
+# ============================================================================
+FROM dhi.io/mysql:8.4
+
+# Copy binaries only
+# Note: Some binaries may not work if they need libraries not in the hardened image
+COPY --from=builder /staging/usr/bin/* /usr/bin/
+
+# Copy healthcheck script
+COPY --from=builder /staging/healthcheck.sh /healthcheck.sh
+
+# Switch to mysql user (hardened image enforces this)
+USER mysql
+
+# Set working directory
+WORKDIR /var/lib/mysql
+
+# Expose MySQL port
+EXPOSE 3306
+
+# Healthcheck for DDEV compatibility
+HEALTHCHECK --interval=2s --retries=30 --start-period=120s --timeout=10s \
+    CMD ["/healthcheck.sh"]
+
+# Let the base image handle CMD/ENTRYPOINT

--- a/.ddev/mysql/copy-with-deps.sh
+++ b/.ddev/mysql/copy-with-deps.sh
@@ -1,0 +1,44 @@
+#!/bin/bash
+# Copy a binary and all its shared library dependencies
+
+set -euo pipefail
+
+BINARY_NAME=$1
+DEST_ROOT=$2
+
+# Find the binary
+BINARY_PATH=$(which "$BINARY_NAME" 2>/dev/null || true)
+if [ -z "$BINARY_PATH" ]; then
+    echo "WARNING: Binary $BINARY_NAME not found, skipping"
+    exit 0
+fi
+
+echo "Processing $BINARY_NAME from $BINARY_PATH"
+
+# Copy the binary itself
+BIN_DIR=$(dirname "$BINARY_PATH")
+mkdir -p "$DEST_ROOT$BIN_DIR"
+cp -L "$BINARY_PATH" "$DEST_ROOT$BIN_DIR/"
+
+# Find and copy all shared library dependencies
+ldd "$BINARY_PATH" 2>/dev/null | grep "=> /" | awk '{print $3}' | while read -r lib; do
+    if [ -f "$lib" ]; then
+        LIB_DIR=$(dirname "$lib")
+        mkdir -p "$DEST_ROOT$LIB_DIR"
+        # Use -L to follow symlinks and copy actual file
+        cp -L "$lib" "$DEST_ROOT$LIB_DIR/" 2>/dev/null || true
+        echo "  Copied dependency: $lib"
+    fi
+done
+
+# Also handle the dynamic linker (ld-linux)
+ldd "$BINARY_PATH" 2>/dev/null | grep "ld-linux" | awk '{print $1}' | while read -r linker; do
+    if [ -f "$linker" ]; then
+        LINKER_DIR=$(dirname "$linker")
+        mkdir -p "$DEST_ROOT$LINKER_DIR"
+        cp -L "$linker" "$DEST_ROOT$LINKER_DIR/" 2>/dev/null || true
+        echo "  Copied linker: $linker"
+    fi
+done
+
+echo "Completed $BINARY_NAME"

--- a/.ddev/mysql/healthcheck.sh
+++ b/.ddev/mysql/healthcheck.sh
@@ -1,0 +1,11 @@
+#!/bin/bash
+# Simple healthcheck for MySQL
+# Uses mysqladmin if available, otherwise tries mysql client
+
+set -e
+
+if command -v mysqladmin >/dev/null 2>&1; then
+    mysqladmin ping -h localhost >/dev/null 2>&1
+else
+    mysql -h localhost -e "SELECT 1" >/dev/null 2>&1
+fi

--- a/web/sites/default/settings.mysql84.php
+++ b/web/sites/default/settings.mysql84.php
@@ -1,0 +1,9 @@
+<?php
+
+$host = "mysql84";
+$databases['default']['default']['database'] = "db";
+$databases['default']['default']['username'] = "root";
+$databases['default']['default']['password'] = "root";
+$databases['default']['default']['host'] = $host;
+$databases['default']['default']['port'] = $port;
+$databases['default']['default']['driver'] = $driver;

--- a/web/sites/default/settings.php
+++ b/web/sites/default/settings.php
@@ -888,3 +888,7 @@ if (getenv('PLATFORM_PROJECT_ENTROPY') != "") {
 if ((file_exists(__DIR__ . '/settings.ddev.redis.php') && getenv('IS_DDEV_PROJECT') == 'true')) {
   include __DIR__ . '/settings.ddev.redis.php';
 }
+
+if (getenv('IS_DDEV_PROJECT') == 'true' && file_exists(__DIR__ . '/settings.mysql84.php')) {
+  include __DIR__ . '/settings.mysql84.php';
+}


### PR DESCRIPTION
* ddev/ddev#7962

Copilot-created experiment with hardened mysql 8.4, added as extra service. 

> I've successfully created a DDEV additional service using Docker's
   hardened MySQL 8.4 image. The service is running and we've learned the
   real-world constraints of hardened images:

   What Works:

     - MySQL 8.4 is running on port 3307
     - Multi-stage build successfully extracts and copies binaries
     - Tools with minimal dependencies (pv, less) work
     - Service integrates with DDEV's docker-compose system

   Key Discoveries:

     - Hardened images truly have no root - can't even create directories
     - Can't mix glibc versions - the hardened image's older glibc conflicts with Debian bookworm libraries
     - Only binaries depending solely on libc work without additional library copying
     - More complex tools (zstd, curl, wget) need their libraries, which creates version conflicts

   The Solution: Created 4 files that demonstrate multi-stage builds with hardened
   images, proving the concept works but with significant practical limitations for
   adding tools beyond what the base image provides.

A cool thing is here, it used the new x-ddev features. That's amazing. https://github.com/rfay/d11/pull/1/files#diff-c9c7fc1f4505ed72ca9803409fbfa1db007cd5ae688ae03af4fdb7a1ebbff864R39-R44

<img width="2130" height="974" alt="image" src="https://github.com/user-attachments/assets/13aad5c1-f788-4bd2-ace0-183d2f2f592b" />

